### PR TITLE
updating token permissions because creating releases requires contents: write

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -6,7 +6,7 @@ on:
       - '*.*.*'
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   wheels:


### PR DESCRIPTION
updating token permissions because creating releases requires `contents: write`